### PR TITLE
refactor: 重构拖拽链路并收紧减伤合法性校验

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
-import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import { useShallow } from 'zustand/shallow';
-import { type Actor, type CooldownEvent, type Job, type MitEvent } from './model/types';
+import { type Actor, type Job } from './model/types';
 import { useStore } from './store';
 import { selectAppActions, selectAppState } from './store/selectors';
-import { getSkillDefinition, withOwnerSkillId } from './data/skills';
+import { getSkillDefinition } from './data/skills';
 import { FFLogsExporter } from './lib/fflogs/exporter';
 import { AppHeader } from './components/AppHeader';
 import { DragOverlayLayer } from './components/DragOverlayLayer';
@@ -20,11 +19,10 @@ import { TimelineToolbar } from './components/Timeline/TimelineToolbar';
 import { TopBannerStack } from './components/TopBanner';
 import { TrashDropZone } from './components/TrashDropZone';
 import { useTopBanner } from './hooks/useTopBanner';
+import { useMitigationDragController } from './hooks/useMitigationDragController';
 import { MS_PER_SEC, TIME_DECIMAL_PLACES } from './constants/time';
 import { DEFAULT_ZOOM } from './constants/timeline';
-import { canInsertMitigation, tryBuildCooldowns } from './utils/playerCast';
 import { getStoredTheme, parseFFLogsUrl, setStoredTheme } from './utils';
-import type { DragItemData, DropZoneData } from './dnd/types';
 
 export default function App() {
   const {
@@ -59,14 +57,6 @@ export default function App() {
   const [exportContent, setExportContent] = useState('');
   const [exportCreatedAt, setExportCreatedAt] = useState('');
   const [enableTTS, setEnableTTS] = useState(false);
-  const [activeItem, setActiveItem] = useState<DragItemData | null>(null);
-  const [dragPreviewPx, setDragPreviewPx] = useState(0);
-  const [dragInvalid, setDragInvalid] = useState(false);
-  const dragPreviewRef = useRef(0);
-  const dragPreviewRafRef = useRef<number | null>(null);
-  const dragInvalidRef = useRef(false);
-  const dragMovingEventsRef = useRef<MitEvent[]>([]);
-  const dragCooldownEventsRef = useRef<CooldownEvent[]>([]);
   const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
   const [loadMode, setLoadMode] = useState<'single' | 'dual'>('single');
   const [dualTankPlayers, setDualTankPlayers] = useState<{ id: number | null; job: Job }[]>([]);
@@ -162,15 +152,6 @@ export default function App() {
     loadEvents,
     loadEventsForPlayers,
   ]);
-
-  const resolveOwnerContext = (job?: Job) => {
-    const resolvedJob = job ?? selectedJob ?? undefined;
-    if (loadMode === 'dual') {
-      const match = dualTankPlayers.find((player) => player.job === resolvedJob);
-      return { ownerJob: resolvedJob, ownerId: match?.id ?? undefined };
-    }
-    return { ownerJob: resolvedJob, ownerId: selectedPlayerId ?? undefined };
-  };
 
   const getEventsToExport = () => {
     const { castEvents, mitEvents } = useStore.getState();
@@ -313,232 +294,26 @@ export default function App() {
     );
   };
 
-  const handleDragStart = (event: DragStartEvent) => {
-    const currentItem = event.active.data.current as DragItemData;
-    setActiveItem(currentItem);
-    if (currentItem?.type === 'new-skill') {
-      setSelectedMitIds([]);
-    }
-    dragInvalidRef.current = false;
-    setDragInvalid(false);
-    if (currentItem?.type === 'existing-mit') {
-      const selectedMitIds = useStore.getState().selectedMitIds;
-      const eventsToMove = selectedMitIds.includes(currentItem.mit.id)
-        ? mitEvents.filter((m) => selectedMitIds.includes(m.id))
-        : [currentItem.mit];
-      dragMovingEventsRef.current = eventsToMove;
-      const movingIds = new Set(eventsToMove.map((m) => m.id));
-      dragCooldownEventsRef.current =
-        tryBuildCooldowns(mitEvents.filter((m) => !movingIds.has(m.id))) ?? [];
-    } else {
-      dragMovingEventsRef.current = [];
-      dragCooldownEventsRef.current = [];
-    }
-    dragPreviewRef.current = 0;
-    if (dragPreviewRafRef.current !== null) {
-      cancelAnimationFrame(dragPreviewRafRef.current);
-      dragPreviewRafRef.current = null;
-    }
-    setDragPreviewPx(0);
-  };
-
-  const handleDragMove = (event: DragEndEvent) => {
-    const { delta } = event;
-    dragPreviewRef.current = delta.y;
-    if (dragPreviewRafRef.current !== null) return;
-    dragPreviewRafRef.current = requestAnimationFrame(() => {
-      dragPreviewRafRef.current = null;
-      setDragPreviewPx(dragPreviewRef.current);
-    });
-
-    const translated = event.active.rect.current?.translated;
-    const over = event.over;
-    const zone = over?.data.current as DropZoneData | undefined;
-    if (!translated || !over || !zone || zone.kind !== 'mit-lane') {
-      if (dragInvalidRef.current) {
-        dragInvalidRef.current = false;
-        setDragInvalid(false);
-      }
-      return;
-    }
-
-    const offsetY = Math.max(0, translated.top - over.rect.top);
-    const tStartMs = offsetY * zone.msPerPx;
-    let isValid = true;
-
-    if (activeItem?.type === 'new-skill') {
-      const { ownerJob, ownerId } = resolveOwnerContext(activeItem.ownerJob);
-      isValid = canInsertMitigation(
-        activeItem.skill.id,
-        tStartMs,
-        mitEvents,
-        ownerJob,
-        ownerId,
-        undefined,
-        cooldownEvents,
-      );
-    } else if (activeItem?.type === 'existing-mit') {
-      const deltaMs = tStartMs - activeItem.mit.tStartMs;
-      const eventsToMove = dragMovingEventsRef.current.length
-        ? dragMovingEventsRef.current
-        : [activeItem.mit];
-      const cooldowns = dragCooldownEventsRef.current;
-      isValid = eventsToMove.every((m) => {
-        const newStart = m.tStartMs + deltaMs;
-        if (newStart < 0) return false;
-        return canInsertMitigation(
-          m.skillId,
-          newStart,
-          mitEvents,
-          m.ownerJob ?? undefined,
-          m.ownerId ?? undefined,
-          undefined,
-          cooldowns,
-        );
-      });
-    }
-
-    if (dragInvalidRef.current === !isValid) return;
-    dragInvalidRef.current = !isValid;
-    setDragInvalid(!isValid);
-  };
-
-  const buildMitEventFromSkill = (
-    skillId: string,
-    tStartMs: number,
-    id = crypto.randomUUID(),
-    ownerJob?: Job,
-    ownerId?: number,
-  ): MitEvent | null => {
-    const skillDef = getSkillDefinition(skillId);
-    if (!skillDef) return null;
-    const durationMs = skillDef.durationSec * MS_PER_SEC;
-    const resolvedOwner = resolveOwnerContext(ownerJob);
-    const resolvedSkillId = withOwnerSkillId(skillDef.id, resolvedOwner.ownerJob);
-    return {
-      eventType: 'mit',
-      id,
-      skillId: resolvedSkillId,
-      tStartMs,
-      durationMs,
-      tEndMs: tStartMs + durationMs,
-      ownerId: ownerId ?? resolvedOwner.ownerId,
-      ownerJob: resolvedOwner.ownerJob,
-    };
-  };
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    setActiveItem(null);
-    dragInvalidRef.current = false;
-    setDragInvalid(false);
-    dragMovingEventsRef.current = [];
-    dragCooldownEventsRef.current = [];
-    dragPreviewRef.current = 0;
-    if (dragPreviewRafRef.current !== null) {
-      cancelAnimationFrame(dragPreviewRafRef.current);
-      dragPreviewRafRef.current = null;
-    }
-    setDragPreviewPx(0);
-    const { active, over } = event;
-    if (!over) return;
-
-    // 用 dnd-kit 的 droppable data + 测量信息来路由：不查 DOM id，多实例更安全。
-    const zone = over.data.current as DropZoneData | undefined;
-    if (!zone) return;
-    const item = active.data.current as DragItemData | undefined;
-    if (!item) return;
-
-    const translated = active.rect.current?.translated;
-    if (!translated) return;
-
-    if (zone.kind === 'trash') {
-      if (item.type !== 'existing-mit') return;
-
-      const selectedMitIds = useStore.getState().selectedMitIds;
-      const idsToRemove = selectedMitIds.includes(item.mit.id) ? selectedMitIds : [item.mit.id];
-      const removeSet = new Set(idsToRemove);
-      setMitEvents(mitEvents.filter((m) => !removeSet.has(m.id)));
-      setSelectedMitIds([]);
-      return;
-    }
-
-    if (zone.kind !== 'mit-lane') return;
-
-    const offsetY = Math.max(0, translated.top - over.rect.top);
-    const tStartMs = offsetY * zone.msPerPx;
-
-    if (item.type === 'new-skill') {
-      const { ownerJob, ownerId } = resolveOwnerContext(item.ownerJob);
-      if (
-        !canInsertMitigation(
-          item.skill.id,
-          tStartMs,
-          mitEvents,
-          ownerJob,
-          ownerId,
-          undefined,
-          cooldownEvents,
-        )
-      ) {
-        push('冷却中，无法放置该技能。', { tone: 'error' });
-        return;
-      }
-      const newMit = buildMitEventFromSkill(item.skill.id, tStartMs, undefined, ownerJob, ownerId);
-      if (!newMit) return;
-      addMitEvent(newMit);
-      return;
-    }
-
-    if (item.type !== 'existing-mit') return;
-
-    // 用“绝对落点时间”而不是原始指针 delta (delta) 来算移动量，缩放/测量变化时更稳定。
-    const deltaMs = tStartMs - item.mit.tStartMs;
-    let eventsToMove: MitEvent[] = [];
-
-    const selectedMitIds = useStore.getState().selectedMitIds;
-    if (selectedMitIds.includes(item.mit.id)) {
-      eventsToMove = mitEvents.filter((m) => selectedMitIds.includes(m.id));
-    } else {
-      eventsToMove = [item.mit];
-    }
-
-    const movingIds = new Set(eventsToMove.map((m) => m.id));
-    const cooldownEventsForMove =
-      tryBuildCooldowns(mitEvents.filter((m) => !movingIds.has(m.id))) ?? [];
-    const movedEvents = eventsToMove
-      .map((m) => {
-        const newStart = m.tStartMs + deltaMs;
-        if (newStart < 0) return;
-        if (
-          !canInsertMitigation(
-            m.skillId,
-            newStart,
-            mitEvents,
-            m.ownerJob ?? undefined,
-            m.ownerId ?? undefined,
-            undefined,
-            cooldownEventsForMove,
-          )
-        ) {
-          return;
-        }
-
-        return {
-          ...m,
-          tStartMs: newStart,
-          tEndMs: newStart + m.durationMs,
-        };
-      })
-      .filter((m) => m !== undefined);
-
-    if (movedEvents.length !== eventsToMove.length) {
-      push('冷却冲突或时间无效，已取消移动。', { tone: 'error' });
-      return;
-    }
-
-    const movedIds = movedEvents.map((m) => m.id);
-    setMitEvents([...movedEvents, ...mitEvents.filter((m) => !movedIds.includes(m.id))]);
-  };
+  const {
+    activeItem,
+    dragPreviewPx,
+    dragInvalid,
+    handleDragStart,
+    handleDragMove,
+    handleDragEnd,
+    handleDragCancel,
+  } = useMitigationDragController({
+    selectedJob,
+    selectedPlayerId,
+    loadMode,
+    dualTankPlayers,
+    mitEvents,
+    cooldownEvents,
+    addMitEvent,
+    setMitEvents,
+    setSelectedMitIds,
+    push,
+  });
 
   const selectedJobs =
     loadMode === 'dual' ? Array.from(new Set(dualTankPlayers.map((p) => p.job))) : null;
@@ -580,18 +355,7 @@ export default function App() {
       onDragStart={handleDragStart}
       onDragMove={handleDragMove}
       onDragEnd={handleDragEnd}
-      onDragCancel={() => {
-        dragPreviewRef.current = 0;
-        if (dragPreviewRafRef.current !== null) {
-          cancelAnimationFrame(dragPreviewRafRef.current);
-          dragPreviewRafRef.current = null;
-        }
-        dragInvalidRef.current = false;
-        setDragInvalid(false);
-        dragMovingEventsRef.current = [];
-        dragCooldownEventsRef.current = [];
-        setDragPreviewPx(0);
-      }}
+      onDragCancel={handleDragCancel}
     >
       <div className="h-screen overflow-hidden bg-app text-app flex flex-col font-sans">
         <AppHeader

--- a/src/components/Timeline/DraggableMitigation.tsx
+++ b/src/components/Timeline/DraggableMitigation.tsx
@@ -1,12 +1,10 @@
 import { useDraggable } from '@dnd-kit/core';
 import type { MitEvent } from '../../model/types';
-import { useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { MS_PER_SEC, TIME_DECIMAL_PLACES } from '../../constants/time';
 import { getSkillDefinition } from '../../data/skills';
 import { getSkillIconLocalSrc } from '../../data/icons';
 import { MitigationBarContent } from './MitigationBar';
 import { useTopBanner } from '../../hooks/useTopBanner';
+import { MitigationEditPopover } from './MitigationEditPopover';
 
 interface Props {
   mit: MitEvent;
@@ -42,7 +40,6 @@ export function DraggableMitigation({
   onRightClick,
 }: Props) {
   const { push } = useTopBanner();
-  const [isEditInvalid, setIsEditInvalid] = useState(false);
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: mit.id,
     // 为以后跨时间轴（移动/复制）准备；当前单时间轴行为不变。
@@ -59,101 +56,6 @@ export function DraggableMitigation({
     top: 0,
     pointerEvents: 'auto' as const,
   };
-
-  const editInputRef = useRef<HTMLInputElement>(null);
-
-  const handleEditSubmit = () => {
-    const rawValue = editInputRef.current?.value ?? '';
-    const val = parseFloat(rawValue);
-    if (!isNaN(val)) {
-      const nextStartMs = val * MS_PER_SEC;
-      if (Math.abs(nextStartMs - mit.tStartMs) < 0.5) {
-        onEditChange(false);
-        return;
-      }
-      if (canUpdateStart && !canUpdateStart(nextStartMs)) {
-        push('冷却中，无法调整该技能时间。', { tone: 'error' });
-        return;
-      }
-      onEditChange(false);
-      onUpdate(mit.id, {
-        tStartMs: nextStartMs,
-        tEndMs: nextStartMs + mit.durationMs,
-      });
-    }
-  };
-
-  const handleEditBlur = () => {
-    if (!canUpdateStart) return;
-    const rawValue = editInputRef.current?.value ?? '';
-    const val = parseFloat(rawValue);
-    if (isNaN(val)) return;
-    const nextStartMs = val * MS_PER_SEC;
-    setIsEditInvalid(!canUpdateStart(nextStartMs));
-  };
-
-  const editForm = (
-    <div
-      className={`${
-        editPosition ? 'fixed z-50' : 'absolute left-0 top-full z-30 mt-2'
-      } min-w-40 rounded-lg border border-app bg-surface-3 p-3 shadow-2xl backdrop-blur-xl flex flex-col gap-2 text-app`}
-      style={editPosition ? { left: editPosition.x, top: editPosition.y } : undefined}
-      onPointerDown={(e) => e.stopPropagation()}
-    >
-      <label className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted font-mono">
-        编辑事件
-      </label>
-
-      <div className="flex items-center gap-2">
-        <label className="whitespace-nowrap text-[10px] text-muted font-mono">开始(s):</label>
-        <div className="relative">
-          <input
-            autoFocus
-            className={`w-16 rounded-md border bg-surface px-2 py-1 text-[11px] font-mono text-app focus:outline-none focus:ring-2 ${
-              isEditInvalid
-                ? 'border-red-500 focus:ring-red-500/40'
-                : 'border-app focus:ring-(--color-focus)'
-            }`}
-            ref={editInputRef}
-            defaultValue={(mit.tStartMs / MS_PER_SEC).toFixed(TIME_DECIMAL_PLACES)}
-            aria-label="开始时间（秒）"
-            onKeyDown={(e) => e.key === 'Enter' && handleEditSubmit()}
-            onBlur={handleEditBlur}
-            onFocus={() => setIsEditInvalid(false)}
-          />
-          {isEditInvalid && (
-            <span
-              className="absolute -right-5 top-1/2 -translate-y-1/2 text-red-500 text-[20px] font-bold cursor-help"
-              title="CD 冲突，无法应用"
-            >
-              ×
-            </span>
-          )}
-        </div>
-      </div>
-
-      <div className="mt-1 flex items-center justify-between border-t border-app pt-2">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove(mit.id);
-          }}
-          className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-danger transition-colors hover:bg-(--color-danger)/10 hover:text-white active:scale-[0.98]"
-        >
-          <span aria-hidden="true">🗑️</span> 删除
-        </button>
-
-        <button
-          type="button"
-          onClick={handleEditSubmit}
-          className="rounded-md bg-primary-action px-3 py-1 text-[11px] text-white transition-colors hover:bg-[#2ea043] active:scale-[0.98]"
-        >
-          确定
-        </button>
-      </div>
-    </div>
-  );
 
   return (
     <div
@@ -186,11 +88,17 @@ export function DraggableMitigation({
       </div>
 
       {/* 编辑态表单 */}
-      {!isDragging &&
-        isEditing &&
-        (editPosition && typeof document !== 'undefined'
-          ? createPortal(editForm, document.body)
-          : editForm)}
+      {!isDragging && isEditing && (
+        <MitigationEditPopover
+          mit={mit}
+          editPosition={editPosition}
+          canUpdateStart={canUpdateStart}
+          onUpdate={(updates) => onUpdate(mit.id, updates)}
+          onRemove={() => onRemove(mit.id)}
+          onClose={() => onEditChange(false)}
+          onInvalidSubmit={() => push('冷却中，无法调整该技能时间。', { tone: 'error' })}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Timeline/MitigationEditPopover.tsx
+++ b/src/components/Timeline/MitigationEditPopover.tsx
@@ -1,0 +1,128 @@
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { MitEvent } from '../../model/types';
+import { MS_PER_SEC, TIME_DECIMAL_PLACES } from '../../constants/time';
+
+interface Props {
+  mit: MitEvent;
+  editPosition?: { x: number; y: number } | null;
+  canUpdateStart?: (tStartMs: number) => boolean;
+  onUpdate: (updates: Partial<MitEvent>) => void;
+  onRemove: () => void;
+  onClose: () => void;
+  onInvalidSubmit: () => void;
+}
+
+export function MitigationEditPopover({
+  mit,
+  editPosition,
+  canUpdateStart,
+  onUpdate,
+  onRemove,
+  onClose,
+  onInvalidSubmit,
+}: Props) {
+  const [isEditInvalid, setIsEditInvalid] = useState(false);
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  const handleEditSubmit = () => {
+    const rawValue = editInputRef.current?.value ?? '';
+    const val = parseFloat(rawValue);
+    if (isNaN(val)) return;
+
+    const nextStartMs = val * MS_PER_SEC;
+    if (Math.abs(nextStartMs - mit.tStartMs) < 0.5) {
+      onClose();
+      return;
+    }
+
+    if (canUpdateStart && !canUpdateStart(nextStartMs)) {
+      onInvalidSubmit();
+      return;
+    }
+
+    onClose();
+    onUpdate({
+      tStartMs: nextStartMs,
+      tEndMs: nextStartMs + mit.durationMs,
+    });
+  };
+
+  const handleEditBlur = () => {
+    if (!canUpdateStart) return;
+    const rawValue = editInputRef.current?.value ?? '';
+    const val = parseFloat(rawValue);
+    if (isNaN(val)) return;
+    const nextStartMs = val * MS_PER_SEC;
+    setIsEditInvalid(!canUpdateStart(nextStartMs));
+  };
+
+  const content = (
+    <div
+      className={`${
+        editPosition ? 'fixed z-50' : 'absolute left-0 top-full z-30 mt-2'
+      } min-w-40 rounded-lg border border-app bg-surface-3 p-3 shadow-2xl backdrop-blur-xl flex flex-col gap-2 text-app`}
+      style={editPosition ? { left: editPosition.x, top: editPosition.y } : undefined}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <label className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted font-mono">
+        编辑事件
+      </label>
+
+      <div className="flex items-center gap-2">
+        <label className="whitespace-nowrap text-[10px] text-muted font-mono">开始(s):</label>
+        <div className="relative">
+          <input
+            autoFocus
+            className={`w-16 rounded-md border bg-surface px-2 py-1 text-[11px] font-mono text-app focus:outline-none focus:ring-2 ${
+              isEditInvalid
+                ? 'border-red-500 focus:ring-red-500/40'
+                : 'border-app focus:ring-(--color-focus)'
+            }`}
+            ref={editInputRef}
+            defaultValue={(mit.tStartMs / MS_PER_SEC).toFixed(TIME_DECIMAL_PLACES)}
+            aria-label="开始时间（秒）"
+            onKeyDown={(e) => e.key === 'Enter' && handleEditSubmit()}
+            onBlur={handleEditBlur}
+            onFocus={() => setIsEditInvalid(false)}
+          />
+          {isEditInvalid && (
+            <span
+              className="absolute -right-5 top-1/2 -translate-y-1/2 text-red-500 text-[20px] font-bold cursor-help"
+              title="CD 冲突，无法应用"
+            >
+              ×
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-1 flex items-center justify-between border-t border-app pt-2">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-danger transition-colors hover:bg-(--color-danger)/10 hover:text-white active:scale-[0.98]"
+        >
+          <span aria-hidden="true">🗑️</span> 删除
+        </button>
+
+        <button
+          type="button"
+          onClick={handleEditSubmit}
+          className="rounded-md bg-primary-action px-3 py-1 text-[11px] text-white transition-colors hover:bg-[#2ea043] active:scale-[0.98]"
+        >
+          确定
+        </button>
+      </div>
+    </div>
+  );
+
+  if (editPosition && typeof document !== 'undefined') {
+    return createPortal(content, document.body);
+  }
+
+  return content;
+}

--- a/src/components/Timeline/MitigationLayer.tsx
+++ b/src/components/Timeline/MitigationLayer.tsx
@@ -1,7 +1,7 @@
 import type { Job, MitEvent } from '../../model/types';
 import { MS_PER_SEC } from '../../constants/time';
 import { getSkillDefinition, normalizeSkillId } from '../../data/skills';
-import { JOB_ICON_LOCAL_SRC } from '../../data/icons';
+import { getSkillIconLocalSrc, JOB_ICON_LOCAL_SRC } from '../../data/icons';
 import { DraggableMitigation } from './DraggableMitigation';
 import { MitigationBarContent } from './MitigationBar';
 import { getMitigationBarHeights } from './mitigationBarUtils';
@@ -108,7 +108,8 @@ export function MitigationLayer({
           >
             <MitigationBarContent
               headerClassName={`border border-white/10 ${ghostColor}`}
-              showIcon={false}
+              iconSrc={skillDef ? getSkillIconLocalSrc(skillDef.actionId) : undefined}
+              iconAlt={skillDef?.name ?? 'skill icon'}
               effectHeight={effectHeight}
             />
           </div>

--- a/src/domain/drag/mitigationDrag.ts
+++ b/src/domain/drag/mitigationDrag.ts
@@ -1,7 +1,7 @@
 import { withOwnerSkillId, getSkillDefinition } from '../../data/skills';
 import type { CooldownEvent, Job, MitEvent } from '../../model/types';
 import { MS_PER_SEC } from '../../constants/time';
-import { canInsertMitigation } from '../../utils/playerCast';
+import { canInsertMitigation, evaluateMitigationSetStrict } from '../../utils/playerCast';
 
 export interface OwnerContext {
   ownerJob?: Job;
@@ -111,18 +111,8 @@ export function canDropExistingMitigations({
 
   const movingIds = new Set(eventsToMove.map((mit) => mit.id));
   const staticEvents = mitEvents.filter((mit) => !movingIds.has(mit.id));
-  const candidateEvents = [...staticEvents, ...movedEvents];
-
-  return movedEvents.every((mit) =>
-    canInsertMitigation(
-      mit.skillId,
-      mit.tStartMs,
-      candidateEvents,
-      mit.ownerJob ?? undefined,
-      mit.ownerId ?? undefined,
-      new Set([mit.id]),
-    ),
-  );
+  const candidateResult = evaluateMitigationSetStrict([...staticEvents, ...movedEvents]);
+  return candidateResult.ok;
 }
 
 export function buildMovedMitEvents(input: ExistingMitDropValidationInput): MitEvent[] | null {

--- a/src/domain/drag/mitigationDrag.ts
+++ b/src/domain/drag/mitigationDrag.ts
@@ -1,0 +1,143 @@
+import { withOwnerSkillId, getSkillDefinition } from '../../data/skills';
+import type { CooldownEvent, Job, MitEvent } from '../../model/types';
+import { MS_PER_SEC } from '../../constants/time';
+import { canInsertMitigation, tryBuildCooldowns } from '../../utils/playerCast';
+
+export interface OwnerContext {
+  ownerJob?: Job;
+  ownerId?: number;
+}
+
+export interface ExistingMitDragContext {
+  eventsToMove: MitEvent[];
+  cooldownEvents: CooldownEvent[];
+}
+
+interface BuildMitEventFromSkillInput extends OwnerContext {
+  skillId: string;
+  tStartMs: number;
+  id?: string;
+}
+
+interface ExistingMitDropValidationInput {
+  sourceMit: MitEvent;
+  tStartMs: number;
+  eventsToMove: MitEvent[];
+  mitEvents: MitEvent[];
+  cooldownEvents: CooldownEvent[];
+}
+
+export function resolveEventsToMove(
+  currentMit: MitEvent,
+  selectedMitIds: string[],
+  mitEvents: MitEvent[],
+): MitEvent[] {
+  if (!selectedMitIds.includes(currentMit.id)) {
+    return [currentMit];
+  }
+  return mitEvents.filter((mit) => selectedMitIds.includes(mit.id));
+}
+
+export function prepareExistingMitDrag(
+  currentMit: MitEvent,
+  selectedMitIds: string[],
+  mitEvents: MitEvent[],
+): ExistingMitDragContext {
+  const eventsToMove = resolveEventsToMove(currentMit, selectedMitIds, mitEvents);
+  const movingIds = new Set(eventsToMove.map((mit) => mit.id));
+  const cooldownEvents = tryBuildCooldowns(mitEvents.filter((mit) => !movingIds.has(mit.id))) ?? [];
+  return { eventsToMove, cooldownEvents };
+}
+
+export function resolveDropStartMs(
+  translatedTop: number,
+  dropTop: number,
+  msPerPx: number,
+): number {
+  return Math.max(0, translatedTop - dropTop) * msPerPx;
+}
+
+export function resolveMitRemovalIds(currentMit: MitEvent, selectedMitIds: string[]): string[] {
+  return selectedMitIds.includes(currentMit.id) ? selectedMitIds : [currentMit.id];
+}
+
+export function buildMitEventFromSkill({
+  skillId,
+  tStartMs,
+  id = crypto.randomUUID(),
+  ownerJob,
+  ownerId,
+}: BuildMitEventFromSkillInput): MitEvent | null {
+  const skillDef = getSkillDefinition(skillId);
+  if (!skillDef) return null;
+
+  const durationMs = skillDef.durationSec * MS_PER_SEC;
+  return {
+    eventType: 'mit',
+    id,
+    skillId: withOwnerSkillId(skillDef.id, ownerJob),
+    tStartMs,
+    durationMs,
+    tEndMs: tStartMs + durationMs,
+    ownerId,
+    ownerJob,
+  };
+}
+
+export function canDropNewMitigation(
+  skillId: string,
+  tStartMs: number,
+  mitEvents: MitEvent[],
+  cooldownEvents: CooldownEvent[],
+  ownerContext: OwnerContext,
+): boolean {
+  return canInsertMitigation(
+    skillId,
+    tStartMs,
+    mitEvents,
+    ownerContext.ownerJob,
+    ownerContext.ownerId,
+    undefined,
+    cooldownEvents,
+  );
+}
+
+export function canDropExistingMitigations({
+  sourceMit,
+  tStartMs,
+  eventsToMove,
+  mitEvents,
+  cooldownEvents,
+}: ExistingMitDropValidationInput): boolean {
+  const deltaMs = tStartMs - sourceMit.tStartMs;
+  return eventsToMove.every((mit) => {
+    const newStart = mit.tStartMs + deltaMs;
+    if (newStart < 0) return false;
+
+    return canInsertMitigation(
+      mit.skillId,
+      newStart,
+      mitEvents,
+      mit.ownerJob ?? undefined,
+      mit.ownerId ?? undefined,
+      undefined,
+      cooldownEvents,
+    );
+  });
+}
+
+export function buildMovedMitEvents(input: ExistingMitDropValidationInput): MitEvent[] | null {
+  if (!canDropExistingMitigations(input)) {
+    return null;
+  }
+
+  const deltaMs = input.tStartMs - input.sourceMit.tStartMs;
+  return input.eventsToMove.map((mit) => {
+    const newStart = mit.tStartMs + deltaMs;
+    return {
+      ...mit,
+      tStartMs: newStart,
+      tEndMs: newStart + mit.durationMs,
+    };
+  });
+}

--- a/src/domain/drag/mitigationDrag.ts
+++ b/src/domain/drag/mitigationDrag.ts
@@ -1,7 +1,7 @@
 import { withOwnerSkillId, getSkillDefinition } from '../../data/skills';
 import type { CooldownEvent, Job, MitEvent } from '../../model/types';
 import { MS_PER_SEC } from '../../constants/time';
-import { canInsertMitigation, tryBuildCooldowns } from '../../utils/playerCast';
+import { canInsertMitigation } from '../../utils/playerCast';
 
 export interface OwnerContext {
   ownerJob?: Job;
@@ -10,7 +10,6 @@ export interface OwnerContext {
 
 export interface ExistingMitDragContext {
   eventsToMove: MitEvent[];
-  cooldownEvents: CooldownEvent[];
 }
 
 interface BuildMitEventFromSkillInput extends OwnerContext {
@@ -24,7 +23,6 @@ interface ExistingMitDropValidationInput {
   tStartMs: number;
   eventsToMove: MitEvent[];
   mitEvents: MitEvent[];
-  cooldownEvents: CooldownEvent[];
 }
 
 export function resolveEventsToMove(
@@ -44,9 +42,7 @@ export function prepareExistingMitDrag(
   mitEvents: MitEvent[],
 ): ExistingMitDragContext {
   const eventsToMove = resolveEventsToMove(currentMit, selectedMitIds, mitEvents);
-  const movingIds = new Set(eventsToMove.map((mit) => mit.id));
-  const cooldownEvents = tryBuildCooldowns(mitEvents.filter((mit) => !movingIds.has(mit.id))) ?? [];
-  return { eventsToMove, cooldownEvents };
+  return { eventsToMove };
 }
 
 export function resolveDropStartMs(
@@ -107,23 +103,26 @@ export function canDropExistingMitigations({
   tStartMs,
   eventsToMove,
   mitEvents,
-  cooldownEvents,
 }: ExistingMitDropValidationInput): boolean {
-  const deltaMs = tStartMs - sourceMit.tStartMs;
-  return eventsToMove.every((mit) => {
-    const newStart = mit.tStartMs + deltaMs;
-    if (newStart < 0) return false;
+  const movedEvents = buildMovedCandidateEvents(sourceMit, tStartMs, eventsToMove);
+  if (!movedEvents) {
+    return false;
+  }
 
-    return canInsertMitigation(
+  const movingIds = new Set(eventsToMove.map((mit) => mit.id));
+  const staticEvents = mitEvents.filter((mit) => !movingIds.has(mit.id));
+  const candidateEvents = [...staticEvents, ...movedEvents];
+
+  return movedEvents.every((mit) =>
+    canInsertMitigation(
       mit.skillId,
-      newStart,
-      mitEvents,
+      mit.tStartMs,
+      candidateEvents,
       mit.ownerJob ?? undefined,
       mit.ownerId ?? undefined,
-      undefined,
-      cooldownEvents,
-    );
-  });
+      new Set([mit.id]),
+    ),
+  );
 }
 
 export function buildMovedMitEvents(input: ExistingMitDropValidationInput): MitEvent[] | null {
@@ -131,13 +130,29 @@ export function buildMovedMitEvents(input: ExistingMitDropValidationInput): MitE
     return null;
   }
 
-  const deltaMs = input.tStartMs - input.sourceMit.tStartMs;
-  return input.eventsToMove.map((mit) => {
+  return buildMovedCandidateEvents(input.sourceMit, input.tStartMs, input.eventsToMove);
+}
+
+function buildMovedCandidateEvents(
+  sourceMit: MitEvent,
+  tStartMs: number,
+  eventsToMove: MitEvent[],
+): MitEvent[] | null {
+  const deltaMs = tStartMs - sourceMit.tStartMs;
+  const movedEvents: MitEvent[] = [];
+
+  for (const mit of eventsToMove) {
     const newStart = mit.tStartMs + deltaMs;
-    return {
+    if (newStart < 0) {
+      return null;
+    }
+
+    movedEvents.push({
       ...mit,
       tStartMs: newStart,
       tEndMs: newStart + mit.durationMs,
-    };
-  });
+    });
+  }
+
+  return movedEvents;
 }

--- a/src/hooks/useMitigationDragController.ts
+++ b/src/hooks/useMitigationDragController.ts
@@ -1,0 +1,260 @@
+import { useCallback, useRef, useState } from 'react';
+import type { DragEndEvent, DragMoveEvent, DragStartEvent } from '@dnd-kit/core';
+import type { CooldownEvent, Job, MitEvent } from '../model/types';
+import type { DragItemData, DropZoneData } from '../dnd/types';
+import { useStore } from '../store';
+import type { PushBanner } from './useTopBanner';
+import {
+  buildMitEventFromSkill,
+  buildMovedMitEvents,
+  canDropExistingMitigations,
+  canDropNewMitigation,
+  prepareExistingMitDrag,
+  resolveDropStartMs,
+  resolveMitRemovalIds,
+} from '../domain/drag/mitigationDrag';
+
+interface DualTankPlayer {
+  id: number | null;
+  job: Job;
+}
+
+interface UseMitigationDragControllerOptions {
+  selectedJob: Job | null;
+  selectedPlayerId: number | null;
+  loadMode: 'single' | 'dual';
+  dualTankPlayers: DualTankPlayer[];
+  mitEvents: MitEvent[];
+  cooldownEvents: CooldownEvent[];
+  addMitEvent: (event: MitEvent) => void;
+  setMitEvents: (events: MitEvent[]) => void;
+  setSelectedMitIds: (ids: string[]) => void;
+  push: PushBanner;
+}
+
+export function useMitigationDragController({
+  selectedJob,
+  selectedPlayerId,
+  loadMode,
+  dualTankPlayers,
+  mitEvents,
+  cooldownEvents,
+  addMitEvent,
+  setMitEvents,
+  setSelectedMitIds,
+  push,
+}: UseMitigationDragControllerOptions) {
+  const [activeItem, setActiveItem] = useState<DragItemData | null>(null);
+  const [dragPreviewPx, setDragPreviewPx] = useState(0);
+  const [dragInvalid, setDragInvalid] = useState(false);
+  const activeItemRef = useRef<DragItemData | null>(null);
+  const dragPreviewRef = useRef(0);
+  const dragPreviewRafRef = useRef<number | null>(null);
+  const dragInvalidRef = useRef(false);
+  const dragMovingEventsRef = useRef<MitEvent[]>([]);
+  const dragCooldownEventsRef = useRef<CooldownEvent[]>([]);
+
+  const resolveOwnerContext = useCallback(
+    (job?: Job) => {
+      const resolvedJob = job ?? selectedJob ?? undefined;
+      if (loadMode === 'dual') {
+        const match = dualTankPlayers.find((player) => player.job === resolvedJob);
+        return { ownerJob: resolvedJob, ownerId: match?.id ?? undefined };
+      }
+      return { ownerJob: resolvedJob, ownerId: selectedPlayerId ?? undefined };
+    },
+    [dualTankPlayers, loadMode, selectedJob, selectedPlayerId],
+  );
+
+  const clearDragRuntime = useCallback(() => {
+    dragInvalidRef.current = false;
+    setDragInvalid(false);
+    dragMovingEventsRef.current = [];
+    dragCooldownEventsRef.current = [];
+    dragPreviewRef.current = 0;
+
+    if (dragPreviewRafRef.current !== null) {
+      cancelAnimationFrame(dragPreviewRafRef.current);
+      dragPreviewRafRef.current = null;
+    }
+
+    setDragPreviewPx(0);
+  }, []);
+
+  const resetDragSession = useCallback(() => {
+    activeItemRef.current = null;
+    setActiveItem(null);
+    clearDragRuntime();
+  }, [clearDragRuntime]);
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const currentItem = event.active.data.current as DragItemData | undefined;
+      activeItemRef.current = currentItem ?? null;
+      setActiveItem(currentItem ?? null);
+
+      if (currentItem?.type === 'new-skill') {
+        setSelectedMitIds([]);
+      }
+
+      clearDragRuntime();
+
+      if (currentItem?.type !== 'existing-mit') {
+        return;
+      }
+
+      const selectedMitIds = useStore.getState().selectedMitIds;
+      const dragContext = prepareExistingMitDrag(currentItem.mit, selectedMitIds, mitEvents);
+      dragMovingEventsRef.current = dragContext.eventsToMove;
+      dragCooldownEventsRef.current = dragContext.cooldownEvents;
+    },
+    [clearDragRuntime, mitEvents, setSelectedMitIds],
+  );
+
+  const handleDragMove = useCallback(
+    (event: DragMoveEvent) => {
+      dragPreviewRef.current = event.delta.y;
+      if (dragPreviewRafRef.current === null) {
+        dragPreviewRafRef.current = requestAnimationFrame(() => {
+          dragPreviewRafRef.current = null;
+          setDragPreviewPx(dragPreviewRef.current);
+        });
+      }
+
+      const translated = event.active.rect.current?.translated;
+      const over = event.over;
+      const zone = over?.data.current as DropZoneData | undefined;
+      if (!translated || !over || !zone || zone.kind !== 'mit-lane') {
+        if (dragInvalidRef.current) {
+          dragInvalidRef.current = false;
+          setDragInvalid(false);
+        }
+        return;
+      }
+
+      const tStartMs = resolveDropStartMs(translated.top, over.rect.top, zone.msPerPx);
+      const currentItem = activeItemRef.current;
+
+      let isValid = true;
+      if (currentItem?.type === 'new-skill') {
+        isValid = canDropNewMitigation(
+          currentItem.skill.id,
+          tStartMs,
+          mitEvents,
+          cooldownEvents,
+          resolveOwnerContext(currentItem.ownerJob),
+        );
+      } else if (currentItem?.type === 'existing-mit') {
+        const eventsToMove = dragMovingEventsRef.current.length
+          ? dragMovingEventsRef.current
+          : [currentItem.mit];
+        isValid = canDropExistingMitigations({
+          sourceMit: currentItem.mit,
+          tStartMs,
+          eventsToMove,
+          mitEvents,
+          cooldownEvents: dragCooldownEventsRef.current,
+        });
+      }
+
+      if (dragInvalidRef.current === !isValid) return;
+      dragInvalidRef.current = !isValid;
+      setDragInvalid(!isValid);
+    },
+    [cooldownEvents, mitEvents, resolveOwnerContext],
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      const item = active.data.current as DragItemData | undefined;
+      const translated = active.rect.current?.translated;
+
+      resetDragSession();
+
+      if (!over || !item || !translated) return;
+
+      const zone = over.data.current as DropZoneData | undefined;
+      if (!zone) return;
+
+      if (zone.kind === 'trash') {
+        if (item.type !== 'existing-mit') return;
+
+        const selectedMitIds = useStore.getState().selectedMitIds;
+        const idsToRemove = resolveMitRemovalIds(item.mit, selectedMitIds);
+        const removeSet = new Set(idsToRemove);
+        setMitEvents(mitEvents.filter((mit) => !removeSet.has(mit.id)));
+        setSelectedMitIds([]);
+        return;
+      }
+
+      if (zone.kind !== 'mit-lane') return;
+      const tStartMs = resolveDropStartMs(translated.top, over.rect.top, zone.msPerPx);
+
+      if (item.type === 'new-skill') {
+        const ownerContext = resolveOwnerContext(item.ownerJob);
+        if (
+          !canDropNewMitigation(item.skill.id, tStartMs, mitEvents, cooldownEvents, ownerContext)
+        ) {
+          push('冷却中，无法放置该技能。', { tone: 'error' });
+          return;
+        }
+
+        const newMit = buildMitEventFromSkill({
+          skillId: item.skill.id,
+          tStartMs,
+          ownerJob: ownerContext.ownerJob,
+          ownerId: ownerContext.ownerId,
+        });
+        if (!newMit) return;
+
+        addMitEvent(newMit);
+        return;
+      }
+
+      if (item.type !== 'existing-mit') return;
+
+      const selectedMitIds = useStore.getState().selectedMitIds;
+      const dragContext = prepareExistingMitDrag(item.mit, selectedMitIds, mitEvents);
+      const movedEvents = buildMovedMitEvents({
+        sourceMit: item.mit,
+        tStartMs,
+        eventsToMove: dragContext.eventsToMove,
+        mitEvents,
+        cooldownEvents: dragContext.cooldownEvents,
+      });
+
+      if (!movedEvents || movedEvents.length !== dragContext.eventsToMove.length) {
+        push('冷却冲突或时间无效，已取消移动。', { tone: 'error' });
+        return;
+      }
+
+      const movedIds = new Set(movedEvents.map((mit) => mit.id));
+      setMitEvents([...movedEvents, ...mitEvents.filter((mit) => !movedIds.has(mit.id))]);
+    },
+    [
+      addMitEvent,
+      cooldownEvents,
+      mitEvents,
+      push,
+      resetDragSession,
+      resolveOwnerContext,
+      setMitEvents,
+      setSelectedMitIds,
+    ],
+  );
+
+  const handleDragCancel = useCallback(() => {
+    resetDragSession();
+  }, [resetDragSession]);
+
+  return {
+    activeItem,
+    dragPreviewPx,
+    dragInvalid,
+    handleDragStart,
+    handleDragMove,
+    handleDragEnd,
+    handleDragCancel,
+  };
+}

--- a/src/hooks/useMitigationDragController.ts
+++ b/src/hooks/useMitigationDragController.ts
@@ -52,7 +52,6 @@ export function useMitigationDragController({
   const dragPreviewRafRef = useRef<number | null>(null);
   const dragInvalidRef = useRef(false);
   const dragMovingEventsRef = useRef<MitEvent[]>([]);
-  const dragCooldownEventsRef = useRef<CooldownEvent[]>([]);
 
   const resolveOwnerContext = useCallback(
     (job?: Job) => {
@@ -70,7 +69,6 @@ export function useMitigationDragController({
     dragInvalidRef.current = false;
     setDragInvalid(false);
     dragMovingEventsRef.current = [];
-    dragCooldownEventsRef.current = [];
     dragPreviewRef.current = 0;
 
     if (dragPreviewRafRef.current !== null) {
@@ -106,7 +104,6 @@ export function useMitigationDragController({
       const selectedMitIds = useStore.getState().selectedMitIds;
       const dragContext = prepareExistingMitDrag(currentItem.mit, selectedMitIds, mitEvents);
       dragMovingEventsRef.current = dragContext.eventsToMove;
-      dragCooldownEventsRef.current = dragContext.cooldownEvents;
     },
     [clearDragRuntime, mitEvents, setSelectedMitIds],
   );
@@ -153,7 +150,6 @@ export function useMitigationDragController({
           tStartMs,
           eventsToMove,
           mitEvents,
-          cooldownEvents: dragCooldownEventsRef.current,
         });
       }
 
@@ -221,7 +217,6 @@ export function useMitigationDragController({
         tStartMs,
         eventsToMove: dragContext.eventsToMove,
         mitEvents,
-        cooldownEvents: dragContext.cooldownEvents,
       });
 
       if (!movedEvents || movedEvents.length !== dragContext.eventsToMove.length) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,7 +17,7 @@ import { buildCastEvents } from '../domain/fflogs/buildCastEvents';
 import { buildMitEvents } from '../domain/fflogs/buildMitEvents';
 import { buildDamageEventsByJob } from '../domain/fflogs/buildDamageEventsByJob';
 import { mergeDamageEvents } from '../domain/fflogs/mergeDamageEvents';
-import { tryBuildCooldowns } from '../utils/playerCast';
+import { buildCooldownsTolerant, evaluateMitigationSetStrict } from '../utils/playerCast';
 import { parseFFLogsUrl } from '../utils';
 
 export interface AppState {
@@ -153,7 +153,7 @@ const loadEventsCore = async ({
     withOwnerSkillId,
   );
 
-  const cooldownEvents = tryBuildCooldowns(mitEvents) ?? [];
+  const cooldownEvents = buildCooldownsTolerant(mitEvents);
   const primaryDamageEvents = damagesByPlayer[0]
     ? mergeDamageEvents(damagesByPlayer[0].events, fight.start)
     : [];
@@ -218,303 +218,293 @@ const isAbortError = (error: unknown, signal: AbortSignal) => {
 
 export const useStore = create<AppState>()(
   persist(
-    (set, get) => ({
-      apiKey: '',
-      fflogsUrl: '',
-      fight: null,
-      actors: [],
-      bossIds: [],
-      selectedJob: 'GNB',
-      selectedPlayerId: null,
-      selectedMitIds: [],
-      damageEvents: [],
-      damageEventsByJob: {},
-      castEvents: [],
-      mitEvents: [],
-      cooldownEvents: [],
-      banners: [],
-      isLoading: false,
-      isRendering: false,
-      error: null,
+    (set, get) => {
+      const commitMitigationSet = (events: MitEvent[]) => {
+        const result = evaluateMitigationSetStrict(events);
+        if (!result.ok) {
+          return result;
+        }
 
-      setApiKey: (key) => set({ apiKey: key }),
-      setFflogsUrl: (url) => set({ fflogsUrl: url }),
-      setSelectedJob: (job) => set({ selectedJob: job }),
-      setSelectedPlayerId: (id) => set({ selectedPlayerId: id }),
-      setSelectedMitIds: (ids) => set({ selectedMitIds: ids }),
-      setIsRendering: (is) => set({ isRendering: is }),
-      pushBanner: (message, options) => {
-        const id = ++bannerSeq;
-        const durationMs = options?.durationMs ?? BANNER_DEFAULT_DURATION_MS;
+        set({ mitEvents: result.mitEvents, cooldownEvents: result.cooldownEvents });
+        return result;
+      };
 
-        set((state) => {
-          const next = [
-            ...state.banners,
-            {
-              id,
-              message,
-              tone: options?.tone ?? 'info',
-              closing: false,
-              durationMs,
-            },
-          ];
+      return {
+        apiKey: '',
+        fflogsUrl: '',
+        fight: null,
+        actors: [],
+        bossIds: [],
+        selectedJob: 'GNB',
+        selectedPlayerId: null,
+        selectedMitIds: [],
+        damageEvents: [],
+        damageEventsByJob: {},
+        castEvents: [],
+        mitEvents: [],
+        cooldownEvents: [],
+        banners: [],
+        isLoading: false,
+        isRendering: false,
+        error: null,
 
-          if (next.length > BANNER_MAX) {
-            const removalIndex = next.findIndex((item) => item.durationMs !== null);
-            const index = removalIndex === -1 ? 0 : removalIndex;
-            const removed = next[index];
-            if (removed) {
-              clearBannerTimer(removed.id);
+        setApiKey: (key) => set({ apiKey: key }),
+        setFflogsUrl: (url) => set({ fflogsUrl: url }),
+        setSelectedJob: (job) => set({ selectedJob: job }),
+        setSelectedPlayerId: (id) => set({ selectedPlayerId: id }),
+        setSelectedMitIds: (ids) => set({ selectedMitIds: ids }),
+        setIsRendering: (is) => set({ isRendering: is }),
+        pushBanner: (message, options) => {
+          const id = ++bannerSeq;
+          const durationMs = options?.durationMs ?? BANNER_DEFAULT_DURATION_MS;
+
+          set((state) => {
+            const next = [
+              ...state.banners,
+              {
+                id,
+                message,
+                tone: options?.tone ?? 'info',
+                closing: false,
+                durationMs,
+              },
+            ];
+
+            if (next.length > BANNER_MAX) {
+              const removalIndex = next.findIndex((item) => item.durationMs !== null);
+              const index = removalIndex === -1 ? 0 : removalIndex;
+              const removed = next[index];
+              if (removed) {
+                clearBannerTimer(removed.id);
+              }
+              return { banners: next.filter((_, i) => i !== index) };
             }
-            return { banners: next.filter((_, i) => i !== index) };
+
+            return { banners: next };
+          });
+
+          if (durationMs !== null && typeof window !== 'undefined') {
+            const timer = window.setTimeout(() => {
+              set((state) => ({
+                banners: state.banners.map((item) =>
+                  item.id === id ? { ...item, closing: true } : item,
+                ),
+              }));
+
+              const closeTimer = window.setTimeout(() => {
+                set((state) => ({
+                  banners: state.banners.filter((item) => item.id !== id),
+                }));
+                clearBannerTimer(id);
+              }, BANNER_CLOSE_MS);
+              bannerTimers.set(id, closeTimer);
+            }, durationMs);
+            bannerTimers.set(id, timer);
           }
 
-          return { banners: next };
-        });
+          return id;
+        },
+        closeBanner: (id) => {
+          clearBannerTimer(id);
+          set((state) => ({
+            banners: state.banners.map((item) =>
+              item.id === id ? { ...item, closing: true } : item,
+            ),
+          }));
 
-        if (durationMs !== null && typeof window !== 'undefined') {
+          if (typeof window === 'undefined') {
+            set((state) => ({
+              banners: state.banners.filter((item) => item.id !== id),
+            }));
+            return;
+          }
+
           const timer = window.setTimeout(() => {
             set((state) => ({
-              banners: state.banners.map((item) =>
-                item.id === id ? { ...item, closing: true } : item,
-              ),
+              banners: state.banners.filter((item) => item.id !== id),
             }));
-
-            const closeTimer = window.setTimeout(() => {
-              set((state) => ({
-                banners: state.banners.filter((item) => item.id !== id),
-              }));
-              clearBannerTimer(id);
-            }, BANNER_CLOSE_MS);
-            bannerTimers.set(id, closeTimer);
-          }, durationMs);
+            clearBannerTimer(id);
+          }, BANNER_CLOSE_MS);
           bannerTimers.set(id, timer);
-        }
+        },
 
-        return id;
-      },
-      closeBanner: (id) => {
-        clearBannerTimer(id);
-        set((state) => ({
-          banners: state.banners.map((item) =>
-            item.id === id ? { ...item, closing: true } : item,
-          ),
-        }));
+        loadFightMetadata: async () => {
+          const { requestId, signal } = beginFightRequest();
+          const { apiKey, fflogsUrl } = get();
+          const parsed = parseFFLogsUrl(fflogsUrl);
+          const reportCode = parsed?.reportCode;
+          const fightId = parsed?.fightId;
 
-        if (typeof window === 'undefined') {
-          set((state) => ({
-            banners: state.banners.filter((item) => item.id !== id),
-          }));
-          return;
-        }
-
-        const timer = window.setTimeout(() => {
-          set((state) => ({
-            banners: state.banners.filter((item) => item.id !== id),
-          }));
-          clearBannerTimer(id);
-        }, BANNER_CLOSE_MS);
-        bannerTimers.set(id, timer);
-      },
-
-      loadFightMetadata: async () => {
-        const { requestId, signal } = beginFightRequest();
-        const { apiKey, fflogsUrl } = get();
-        const parsed = parseFFLogsUrl(fflogsUrl);
-        const reportCode = parsed?.reportCode;
-        const fightId = parsed?.fightId;
-
-        if (!apiKey || !reportCode) {
-          if (requestId !== fightRequestSeq) return;
-          const msg = !apiKey ? '未输入 API Key' : 'FFLogs URL 不合法';
-          set({ error: msg, isLoading: false });
-          get().pushBanner(msg, { tone: 'error' });
-          return;
-        }
-
-        set({ isLoading: true, error: null });
-        try {
-          const client = new FFLogsClient(apiKey);
-          const report = await client.fetchReport(reportCode, signal);
-          if (requestId !== fightRequestSeq || signal.aborted) return;
-
-          let fightMeta;
-          if (fightId === 'last') {
-            // 选择报告中最后一场战斗
-            fightMeta = report.fights[report.fights.length - 1];
-          } else {
-            // 按战斗 ID 查找战斗
-            fightMeta = report.fights.find((f) => f.id === Number(fightId));
+          if (!apiKey || !reportCode) {
+            if (requestId !== fightRequestSeq) return;
+            const msg = !apiKey ? '未输入 API Key' : 'FFLogs URL 不合法';
+            set({ error: msg, isLoading: false });
+            get().pushBanner(msg, { tone: 'error' });
+            return;
           }
 
-          if (!fightMeta) {
-            throw new Error('报告中未找到该 Fight ID');
-          }
+          set({ isLoading: true, error: null });
+          try {
+            const client = new FFLogsClient(apiKey);
+            const report = await client.fetchReport(reportCode, signal);
+            if (requestId !== fightRequestSeq || signal.aborted) return;
 
-          const fight: Fight = {
-            id: fightMeta.id,
-            start: fightMeta.start_time,
-            end: fightMeta.end_time,
-            durationMs: fightMeta.end_time - fightMeta.start_time,
-            name: fightMeta.name,
-            zoneID: fightMeta.zoneID,
-            fflogsBoss: fightMeta.boss,
-          };
-
-          const actors: Actor[] = report.friendlies
-            .filter((f) => f.type !== 'LimitBreak' && f.type !== 'Environment') // 过滤非战斗单位
-            .filter((f) => f.fights?.some((fightRef) => fightRef.id === fightMeta.id))
-            .map((f) => ({
-              id: f.id,
-              name: f.name,
-              type: f.type,
-              subType: f.type, // 兼容旧字段
-            }));
-
-          // 记录当前战斗中的 Boss
-          const bossIds: number[] = [];
-          report.enemies.forEach((e) => {
-            if (e.type === 'Boss' && e.fights.some((f) => f.id === fight.id)) {
-              bossIds.push(e.id);
+            let fightMeta;
+            if (fightId === 'last') {
+              // 选择报告中最后一场战斗
+              fightMeta = report.fights[report.fights.length - 1];
+            } else {
+              // 按战斗 ID 查找战斗
+              fightMeta = report.fights.find((f) => f.id === Number(fightId));
             }
-          });
 
-          set({ fight, actors, bossIds, isLoading: false });
-        } catch (err: unknown) {
-          if (requestId !== fightRequestSeq || isAbortError(err, signal)) return;
-          console.error(err);
-          const rawMsg = err instanceof Error ? err.message : String(err);
-          const msg = rawMsg || '加载战斗失败';
-          set({ error: msg, isLoading: false });
-          get().pushBanner(msg, { tone: 'error' });
-        }
-      },
+            if (!fightMeta) {
+              throw new Error('报告中未找到该 Fight ID');
+            }
 
-      loadEvents: async () => {
-        const { apiKey, fflogsUrl, fight, selectedPlayerId, selectedJob, bossIds } = get();
-        const { reportCode } = parseFFLogsUrl(fflogsUrl) ?? {};
-        if (!apiKey || !reportCode || !fight || !selectedPlayerId) return;
+            const fight: Fight = {
+              id: fightMeta.id,
+              start: fightMeta.start_time,
+              end: fightMeta.end_time,
+              durationMs: fightMeta.end_time - fightMeta.start_time,
+              name: fightMeta.name,
+              zoneID: fightMeta.zoneID,
+              fflogsBoss: fightMeta.boss,
+            };
 
-        // 标记渲染中，等待 Timeline 通知完成
-        const { requestId, signal } = beginEventsRequest();
-        set({ isLoading: true, isRendering: true, error: null });
-        const client = new FFLogsClient(apiKey);
+            const actors: Actor[] = report.friendlies
+              .filter((f) => f.type !== 'LimitBreak' && f.type !== 'Environment') // 过滤非战斗单位
+              .filter((f) => f.fights?.some((fightRef) => fightRef.id === fightMeta.id))
+              .map((f) => ({
+                id: f.id,
+                name: f.name,
+                type: f.type,
+                subType: f.type, // 兼容旧字段
+              }));
 
-        try {
-          const { damageEvents, damageEventsByJob, castEvents, mitEvents, cooldownEvents } =
-            await loadEventsCore({
-              client,
-              reportCode,
-              fight,
-              bossIds,
-              players: [{ id: selectedPlayerId, job: selectedJob ?? undefined }],
-              signal,
+            // 记录当前战斗中的 Boss
+            const bossIds: number[] = [];
+            report.enemies.forEach((e) => {
+              if (e.type === 'Boss' && e.fights.some((f) => f.id === fight.id)) {
+                bossIds.push(e.id);
+              }
             });
-          if (requestId !== eventsRequestSeq || signal.aborted) return;
 
-          set({
-            damageEvents,
-            damageEventsByJob,
-            castEvents,
-            mitEvents,
-            cooldownEvents,
-            isLoading: false,
-            // 等待 Timeline 通知渲染完成后再取消遮罩
-          });
-        } catch (err: unknown) {
-          if (requestId !== eventsRequestSeq || isAbortError(err, signal)) return;
-          console.error(err);
-          const rawMsg = err instanceof Error ? err.message : String(err);
-          const msg = rawMsg || '加载事件失败';
-          set({ error: msg, isLoading: false, isRendering: false });
-          get().pushBanner(msg, { tone: 'error' });
-        }
-      },
+            set({ fight, actors, bossIds, isLoading: false });
+          } catch (err: unknown) {
+            if (requestId !== fightRequestSeq || isAbortError(err, signal)) return;
+            console.error(err);
+            const rawMsg = err instanceof Error ? err.message : String(err);
+            const msg = rawMsg || '加载战斗失败';
+            set({ error: msg, isLoading: false });
+            get().pushBanner(msg, { tone: 'error' });
+          }
+        },
 
-      loadEventsForPlayers: async (players) => {
-        const { apiKey, fflogsUrl, fight, bossIds } = get();
-        const { reportCode } = parseFFLogsUrl(fflogsUrl) ?? {};
-        if (!apiKey || !reportCode || !fight || players.length === 0) return;
+        loadEvents: async () => {
+          const { apiKey, fflogsUrl, fight, selectedPlayerId, selectedJob, bossIds } = get();
+          const { reportCode } = parseFFLogsUrl(fflogsUrl) ?? {};
+          if (!apiKey || !reportCode || !fight || !selectedPlayerId) return;
 
-        const { requestId, signal } = beginEventsRequest();
-        set({ isLoading: true, isRendering: true, error: null });
-        const client = new FFLogsClient(apiKey);
+          // 标记渲染中，等待 Timeline 通知完成
+          const { requestId, signal } = beginEventsRequest();
+          set({ isLoading: true, isRendering: true, error: null });
+          const client = new FFLogsClient(apiKey);
 
-        try {
-          const { damageEvents, damageEventsByJob, castEvents, mitEvents, cooldownEvents } =
-            await loadEventsCore({
-              client,
-              reportCode,
-              fight,
-              bossIds,
-              players,
-              signal,
+          try {
+            const { damageEvents, damageEventsByJob, castEvents, mitEvents, cooldownEvents } =
+              await loadEventsCore({
+                client,
+                reportCode,
+                fight,
+                bossIds,
+                players: [{ id: selectedPlayerId, job: selectedJob ?? undefined }],
+                signal,
+              });
+            if (requestId !== eventsRequestSeq || signal.aborted) return;
+
+            set({
+              damageEvents,
+              damageEventsByJob,
+              castEvents,
+              mitEvents,
+              cooldownEvents,
+              isLoading: false,
+              // 等待 Timeline 通知渲染完成后再取消遮罩
             });
-          if (requestId !== eventsRequestSeq || signal.aborted) return;
+          } catch (err: unknown) {
+            if (requestId !== eventsRequestSeq || isAbortError(err, signal)) return;
+            console.error(err);
+            const rawMsg = err instanceof Error ? err.message : String(err);
+            const msg = rawMsg || '加载事件失败';
+            set({ error: msg, isLoading: false, isRendering: false });
+            get().pushBanner(msg, { tone: 'error' });
+          }
+        },
 
-          const primaryJob = players[0]?.job;
-          const primaryDamages = primaryJob ? (damageEventsByJob[primaryJob] ?? []) : damageEvents;
-          set({
-            damageEvents: primaryDamages,
-            damageEventsByJob,
-            castEvents,
-            mitEvents,
-            cooldownEvents,
-            isLoading: false,
-          });
-        } catch (err: unknown) {
-          if (requestId !== eventsRequestSeq || isAbortError(err, signal)) return;
-          console.error(err);
-          const rawMsg = err instanceof Error ? err.message : String(err);
-          const msg = rawMsg || '加载事件失败';
-          set({ error: msg, isLoading: false, isRendering: false });
-          get().pushBanner(msg, { tone: 'error' });
-        }
-      },
+        loadEventsForPlayers: async (players) => {
+          const { apiKey, fflogsUrl, fight, bossIds } = get();
+          const { reportCode } = parseFFLogsUrl(fflogsUrl) ?? {};
+          if (!apiKey || !reportCode || !fight || players.length === 0) return;
 
-      addMitEvent: (event: MitEvent) => {
-        set((state) => {
-          const newMits = [...state.mitEvents, event];
-          const cooldownEvents = tryBuildCooldowns(newMits) ?? [];
+          const { requestId, signal } = beginEventsRequest();
+          set({ isLoading: true, isRendering: true, error: null });
+          const client = new FFLogsClient(apiKey);
 
-          newMits.sort((a, b) => a.tStartMs - b.tStartMs);
-          return {
-            mitEvents: newMits,
-            cooldownEvents,
-          };
-        });
-      },
+          try {
+            const { damageEvents, damageEventsByJob, castEvents, mitEvents, cooldownEvents } =
+              await loadEventsCore({
+                client,
+                reportCode,
+                fight,
+                bossIds,
+                players,
+                signal,
+              });
+            if (requestId !== eventsRequestSeq || signal.aborted) return;
 
-      updateMitEvent: (id: string, updates: Partial<MitEvent>) => {
-        set((state) => {
-          const newMits = state.mitEvents.map((e) => (e.id === id ? { ...e, ...updates } : e));
-          const cooldownEvents = tryBuildCooldowns(newMits) ?? [];
+            const primaryJob = players[0]?.job;
+            const primaryDamages = primaryJob
+              ? (damageEventsByJob[primaryJob] ?? [])
+              : damageEvents;
+            set({
+              damageEvents: primaryDamages,
+              damageEventsByJob,
+              castEvents,
+              mitEvents,
+              cooldownEvents,
+              isLoading: false,
+            });
+          } catch (err: unknown) {
+            if (requestId !== eventsRequestSeq || isAbortError(err, signal)) return;
+            console.error(err);
+            const rawMsg = err instanceof Error ? err.message : String(err);
+            const msg = rawMsg || '加载事件失败';
+            set({ error: msg, isLoading: false, isRendering: false });
+            get().pushBanner(msg, { tone: 'error' });
+          }
+        },
 
-          newMits.sort((a, b) => a.tStartMs - b.tStartMs);
-          return {
-            mitEvents: newMits,
-            cooldownEvents,
-          };
-        });
-      },
+        addMitEvent: (event: MitEvent) => {
+          const state = get();
+          commitMitigationSet([...state.mitEvents, event]);
+        },
 
-      removeMitEvent: (id: string) =>
-        set((state) => {
-          const newMits = state.mitEvents.filter((e) => e.id !== id);
-          const cooldownEvents = tryBuildCooldowns(newMits) ?? [];
+        updateMitEvent: (id: string, updates: Partial<MitEvent>) => {
+          const state = get();
+          commitMitigationSet(state.mitEvents.map((e) => (e.id === id ? { ...e, ...updates } : e)));
+        },
 
-          return {
-            mitEvents: newMits,
-            cooldownEvents,
-          };
-        }),
+        removeMitEvent: (id: string) => {
+          const state = get();
+          commitMitigationSet(state.mitEvents.filter((e) => e.id !== id));
+        },
 
-      setMitEvents: (events) => {
-        const sortedEvents = [...events].sort((a, b) => a.tStartMs - b.tStartMs);
-        const cooldownEvents = tryBuildCooldowns(sortedEvents) ?? [];
-        set({ mitEvents: sortedEvents, cooldownEvents });
-      },
-    }),
+        setMitEvents: (events) => {
+          commitMitigationSet(events);
+        },
+      };
+    },
     {
       name: 'xiv-mit-composer-storage',
       version: 1,

--- a/src/utils/playerCast.ts
+++ b/src/utils/playerCast.ts
@@ -9,21 +9,93 @@ import type { CooldownEvent, Job, MitEvent } from '../model/types';
 import { BinaryHeap } from './BinaryHeap';
 
 const GROUP_PREFIX = 'grp:';
+
+type BuildMode = 'strict' | 'tolerant';
+
+export interface CooldownBuildFailure {
+  ok: false;
+  code:
+    | 'UNKNOWN_SKILL'
+    | 'UNKNOWN_GROUP'
+    | 'NEGATIVE_STACK'
+    | 'MISSING_OPEN_COOLDOWN'
+    | 'DUPLICATE_OPEN_COOLDOWN'
+    | 'UNCLOSED_COOLDOWN';
+  message: string;
+}
+
+export interface CooldownBuildSuccess {
+  ok: true;
+  cooldownEvents: CooldownEvent[];
+}
+
+export type CooldownBuildResult = CooldownBuildSuccess | CooldownBuildFailure;
+
+export type MitigationStateFailure = CooldownBuildFailure;
+
+export interface MitigationStateSuccess {
+  ok: true;
+  mitEvents: MitEvent[];
+  cooldownEvents: CooldownEvent[];
+}
+
+export type MitigationStateResult = MitigationStateSuccess | MitigationStateFailure;
+
+class CooldownBuildError extends Error {
+  code: CooldownBuildFailure['code'];
+
+  constructor(code: CooldownBuildFailure['code'], message: string) {
+    super(message);
+    this.name = 'CooldownBuildError';
+    this.code = code;
+  }
+}
+
 const buildOwnerKey = (ownerId?: number, ownerJob?: Job) => {
   if (typeof ownerId === 'number') return `id:${ownerId}`;
   if (ownerJob) return `job:${ownerJob}`;
   return undefined;
 };
 
+function sortMitEvents(events: MitEvent[]) {
+  return [...events].sort((a, b) => a.tStartMs - b.tStartMs);
+}
+
+export function buildCooldownsStrict(events: MitEvent[]): CooldownBuildResult {
+  try {
+    return { ok: true, cooldownEvents: buildCooldownEventsInternal(events, 'strict') };
+  } catch (error) {
+    if (error instanceof CooldownBuildError) {
+      return {
+        ok: false,
+        code: error.code,
+        message: error.message,
+      };
+    }
+    throw error;
+  }
+}
+
+export function buildCooldownsTolerant(events: MitEvent[]): CooldownEvent[] {
+  return buildCooldownEventsInternal(events, 'tolerant');
+}
+
+export function evaluateMitigationSetStrict(events: MitEvent[]): MitigationStateResult {
+  const mitEvents = sortMitEvents(events);
+  const cooldownResult = buildCooldownsStrict(mitEvents);
+  if (!cooldownResult.ok) {
+    return cooldownResult;
+  }
+
+  return {
+    ok: true,
+    mitEvents,
+    cooldownEvents: cooldownResult.cooldownEvents,
+  };
+}
+
 export function tryBuildCooldowns(events: MitEvent[]): CooldownEvent[] | void {
-  const stackEvents = buildStackEvents(events);
-
-  const skillStacksCounts = buildBoundaries(stackEvents);
-  if (!skillStacksCounts) return;
-
-  const newEvents = buildCooldownEvents(skillStacksCounts);
-  newEvents.sort((a, b) => a.tStartMs - b.tStartMs);
-  return newEvents;
+  return buildCooldownsTolerant(events);
 }
 
 export function canInsertMitigation(
@@ -42,15 +114,19 @@ export function canInsertMitigation(
     return false;
   }
 
-  const resolvedCooldownEvents =
-    cooldownEvents ??
-    (() => {
-      const filteredEvents =
-        excludeIds && excludeIds.size
-          ? allEvents.filter((event) => !excludeIds.has(event.id))
-          : allEvents;
-      return tryBuildCooldowns(filteredEvents) ?? [];
-    })();
+  let resolvedCooldownEvents = cooldownEvents;
+  if (!resolvedCooldownEvents) {
+    const filteredEvents =
+      excludeIds && excludeIds.size
+        ? allEvents.filter((event) => !excludeIds.has(event.id))
+        : allEvents;
+    const result = buildCooldownsStrict(filteredEvents);
+    if (!result.ok) {
+      return false;
+    }
+    resolvedCooldownEvents = result.cooldownEvents;
+  }
+
   const ownerKey = buildOwnerKey(ownerId, ownerJob);
 
   for (const cooldown of resolvedCooldownEvents) {
@@ -77,63 +153,6 @@ interface StackEvent {
   tMs: number;
 }
 
-const stackEventOrder: Record<StackEvent['type'], number> = { recover: 0, consume: 1 };
-
-function buildStackEvents(mitEvents: MitEvent[]): BinaryHeap<StackEvent> {
-  const stackEvents: BinaryHeap<StackEvent> = new BinaryHeap<StackEvent>(
-    (a, b) => a.tMs - b.tMs || stackEventOrder[a.type] - stackEventOrder[b.type],
-  );
-
-  for (const event of mitEvents) {
-    const baseSkillId = normalizeSkillId(event.skillId);
-    const skillMeta = getSkillDefinition(baseSkillId);
-
-    if (!skillMeta) {
-      console.error(`致命错误：未找到技能 ${baseSkillId} 的定义。`);
-      continue;
-    }
-
-    const ownerKey = buildOwnerKey(event.ownerId, event.ownerJob);
-    const skillResourceKey = ownerKey ? `${baseSkillId}:${ownerKey}` : baseSkillId;
-    const skillCooldownMs = skillMeta.cooldownSec * MS_PER_SEC;
-    stackEvents.push({
-      resourceKey: skillResourceKey,
-      ownerKey: ownerKey,
-      ownerJob: event.ownerJob,
-      skillId: baseSkillId,
-      isGroup: false,
-      type: 'consume',
-      cooldownMs: skillCooldownMs,
-      tMs: event.tStartMs,
-    });
-
-    const skillGroupId = skillMeta.cooldownGroup;
-    if (skillGroupId) {
-      const cooldownGroupMeta = COOLDOWN_GROUP_MAP.get(skillGroupId);
-      if (!cooldownGroupMeta) {
-        console.error(`致命错误：未找到技能组 ${skillGroupId} 的定义。`);
-        continue;
-      }
-
-      const groupCooldownMs = cooldownGroupMeta.cooldownSec * MS_PER_SEC;
-      const groupResourceBase = toGroupResourceId(skillGroupId);
-      const groupResourceKey = ownerKey ? `${groupResourceBase}:${ownerKey}` : groupResourceBase;
-      stackEvents.push({
-        resourceKey: groupResourceKey,
-        ownerKey: ownerKey,
-        ownerJob: event.ownerJob,
-        skillId: baseSkillId,
-        isGroup: true,
-        type: 'consume',
-        cooldownMs: groupCooldownMs,
-        tMs: event.tStartMs,
-      });
-    }
-  }
-
-  return stackEvents;
-}
-
 interface CooldownEventBoundary {
   skillId: string;
   resourceId: string;
@@ -143,9 +162,75 @@ interface CooldownEventBoundary {
   boundaryType: 'unusedStart' | 'unusedEnd' | 'cooldownStart' | 'cooldownEnd';
 }
 
+const stackEventOrder: Record<StackEvent['type'], number> = { recover: 0, consume: 1 };
+
+function buildCooldownEventsInternal(events: MitEvent[], mode: BuildMode): CooldownEvent[] {
+  const stackEvents = buildStackEvents(events, mode);
+  const boundaries = buildBoundaries(stackEvents, mode);
+  const cooldownEvents = buildCooldownEvents(boundaries, mode);
+  cooldownEvents.sort((a, b) => a.tStartMs - b.tStartMs);
+  return cooldownEvents;
+}
+
+function buildStackEvents(mitEvents: MitEvent[], mode: BuildMode): BinaryHeap<StackEvent> {
+  const stackEvents: BinaryHeap<StackEvent> = new BinaryHeap<StackEvent>(
+    (a, b) => a.tMs - b.tMs || stackEventOrder[a.type] - stackEventOrder[b.type],
+  );
+
+  for (const event of mitEvents) {
+    const baseSkillId = normalizeSkillId(event.skillId);
+    const skillMeta = getSkillDefinition(baseSkillId);
+
+    if (!skillMeta) {
+      handleBuildFailure(mode, 'UNKNOWN_SKILL', `致命错误：未找到技能 ${baseSkillId} 的定义。`);
+      continue;
+    }
+
+    const ownerKey = buildOwnerKey(event.ownerId, event.ownerJob);
+    const skillResourceKey = ownerKey ? `${baseSkillId}:${ownerKey}` : baseSkillId;
+    const skillCooldownMs = skillMeta.cooldownSec * MS_PER_SEC;
+    stackEvents.push({
+      resourceKey: skillResourceKey,
+      ownerKey,
+      ownerJob: event.ownerJob,
+      skillId: baseSkillId,
+      isGroup: false,
+      type: 'consume',
+      cooldownMs: skillCooldownMs,
+      tMs: event.tStartMs,
+    });
+
+    const skillGroupId = skillMeta.cooldownGroup;
+    if (!skillGroupId) continue;
+
+    const cooldownGroupMeta = COOLDOWN_GROUP_MAP.get(skillGroupId);
+    if (!cooldownGroupMeta) {
+      handleBuildFailure(mode, 'UNKNOWN_GROUP', `致命错误：未找到技能组 ${skillGroupId} 的定义。`);
+      continue;
+    }
+
+    const groupCooldownMs = cooldownGroupMeta.cooldownSec * MS_PER_SEC;
+    const groupResourceBase = toGroupResourceId(skillGroupId);
+    const groupResourceKey = ownerKey ? `${groupResourceBase}:${ownerKey}` : groupResourceBase;
+    stackEvents.push({
+      resourceKey: groupResourceKey,
+      ownerKey,
+      ownerJob: event.ownerJob,
+      skillId: baseSkillId,
+      isGroup: true,
+      type: 'consume',
+      cooldownMs: groupCooldownMs,
+      tMs: event.tStartMs,
+    });
+  }
+
+  return stackEvents;
+}
+
 function buildBoundaries(
   stackEvents: BinaryHeap<StackEvent>,
-): Map<string, CooldownEventBoundary[]> | void {
+  mode: BuildMode,
+): Map<string, CooldownEventBoundary[]> {
   const stacksBuffer = new Map<string, number>();
   const boundaries = new Map<string, CooldownEventBoundary[]>();
   const getSkillKey = (skillId: string, ownerKey?: string) =>
@@ -156,7 +241,6 @@ function buildBoundaries(
     let stack = stacksBuffer.get(stackEvent.resourceKey) ?? initialStack;
 
     if (stackEvent.type === 'consume') {
-      // 消耗事件：若是从满层向下消耗，则需要生成一个恢复事件
       if (stack === initialStack) {
         stackEvents.push({
           ...stackEvent,
@@ -167,7 +251,6 @@ function buildBoundaries(
       stack -= 1;
     } else {
       stack += 1;
-      // 恢复事件：若是还没回满，则生成一个恢复事件
       if (stack !== initialStack) {
         stackEvents.push({
           ...stackEvent,
@@ -178,8 +261,11 @@ function buildBoundaries(
     }
 
     if (stack < 0) {
-      // 容错：异常数据导致负数时重置为 0，保证后续边界可继续生成。
-      console.error(`错误：${stackEvent.resourceKey} 冷却层数为负，已重置为 0。`);
+      handleBuildFailure(
+        mode,
+        'NEGATIVE_STACK',
+        `错误：${stackEvent.resourceKey} 冷却层数为负，无法构建合法的冷却状态。`,
+      );
       stack = 0;
     }
 
@@ -259,13 +345,16 @@ function getInitialStack(stackEvent: StackEvent): number {
   return cooldownGroupMeta?.stack ?? 1;
 }
 
-function buildCooldownEvents(boundaries: Map<string, CooldownEventBoundary[]>): CooldownEvent[] {
+function buildCooldownEvents(
+  boundaries: Map<string, CooldownEventBoundary[]>,
+  mode: BuildMode,
+): CooldownEvent[] {
   const cooldowns: CooldownEvent[] = [];
 
   for (const bs of boundaries.values()) {
     if (!bs.length) continue;
     const skillId = bs[0].skillId;
-    cooldowns.push(...buildCooldownEventsSingle(skillId, bs));
+    cooldowns.push(...buildCooldownEventsSingle(skillId, bs, mode));
   }
 
   return cooldowns;
@@ -274,10 +363,11 @@ function buildCooldownEvents(boundaries: Map<string, CooldownEventBoundary[]>): 
 function buildCooldownEventsSingle(
   skillId: string,
   boundaries: CooldownEventBoundary[],
+  mode: BuildMode,
 ): CooldownEvent[] {
   const skill = getSkillDefinition(skillId);
   if (!skill) {
-    console.error(`致命错误：技能 ${normalizeSkillId(skillId)} 不存在`);
+    handleBuildFailure(mode, 'UNKNOWN_SKILL', `致命错误：技能 ${normalizeSkillId(skillId)} 不存在`);
     return [];
   }
 
@@ -293,7 +383,7 @@ function buildCooldownEventsSingle(
 
   const closeLastCooldown = (tMs: number) => {
     if (lastCooldown === undefined) {
-      console.error(`错误：没有找到未闭合的cooldown`);
+      handleBuildFailure(mode, 'MISSING_OPEN_COOLDOWN', '错误：没有找到未闭合的cooldown。');
       return;
     }
     lastCooldown.tEndMs = tMs;
@@ -304,7 +394,7 @@ function buildCooldownEventsSingle(
 
   const startNewCooldown = (type: CooldownEvent['cdType'], tMs: number) => {
     if (lastCooldown) {
-      console.error(`错误：有未闭合的cooldown`);
+      handleBuildFailure(mode, 'DUPLICATE_OPEN_COOLDOWN', '错误：有未闭合的cooldown。');
       return;
     }
     lastCooldown = {
@@ -354,10 +444,24 @@ function buildCooldownEventsSingle(
         }
         break;
     }
-    boundary.skillId = boundary.skillId ?? skillId;
+  }
+
+  if (lastCooldown || unusableOpenCount !== 0 || cooldownOpenCount !== 0) {
+    handleBuildFailure(mode, 'UNCLOSED_COOLDOWN', `错误：技能 ${skillId} 存在未闭合的冷却区间。`);
   }
 
   return cooldowns;
+}
+
+function handleBuildFailure(
+  mode: BuildMode,
+  code: CooldownBuildFailure['code'],
+  message: string,
+): never | void {
+  if (mode === 'strict') {
+    throw new CooldownBuildError(code, message);
+  }
+  console.error(message);
 }
 
 function toGroupResourceId(groupId: string): string {
@@ -365,7 +469,6 @@ function toGroupResourceId(groupId: string): string {
 }
 
 function stripGroupPrefix(resourceId: string): string {
-  // 约定 resourceId 格式为 baseId:ownerKey，且 baseId 不包含冒号。
   const raw = resourceId.startsWith(GROUP_PREFIX)
     ? resourceId.slice(GROUP_PREFIX.length)
     : resourceId;

--- a/test/mitigationDrag.test.ts
+++ b/test/mitigationDrag.test.ts
@@ -1,0 +1,144 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { Job, MitEvent } from '../src/model/types';
+import {
+  buildMitEventFromSkill,
+  buildMovedMitEvents,
+  canDropExistingMitigations,
+  canDropNewMitigation,
+  prepareExistingMitDrag,
+  resolveDropStartMs,
+  resolveEventsToMove,
+  resolveMitRemovalIds,
+} from '../src/domain/drag/mitigationDrag';
+
+function createMitEvent(
+  skillId: string,
+  tStartMs: number,
+  ownerJob: Job,
+  ownerId = 1,
+  durationMs = 10000,
+): MitEvent {
+  return {
+    eventType: 'mit',
+    id: `${skillId}-${tStartMs}-${ownerId}`,
+    skillId,
+    tStartMs,
+    durationMs,
+    tEndMs: tStartMs + durationMs,
+    ownerJob,
+    ownerId,
+  };
+}
+
+test('resolveEventsToMove 在未选中当前条目时只返回当前事件', () => {
+  const a = createMitEvent('role-rampart', 10_000, 'PLD', 1);
+  const b = createMitEvent('role-reprisal:WAR', 20_000, 'WAR', 2);
+
+  assert.deepEqual(resolveEventsToMove(a, [b.id], [a, b]), [a]);
+});
+
+test('prepareExistingMitDrag 会基于选中项生成移动上下文', () => {
+  const a = createMitEvent('role-rampart', 10_000, 'PLD', 1);
+  const b = createMitEvent('role-reprisal:WAR', 20_000, 'WAR', 2);
+
+  const result = prepareExistingMitDrag(a, [a.id, b.id], [a, b]);
+
+  assert.deepEqual(result.eventsToMove, [a, b]);
+  assert.deepEqual(result.cooldownEvents, []);
+});
+
+test('resolveDropStartMs 会把拖拽落点转换为时间', () => {
+  assert.equal(resolveDropStartMs(180, 80, 100), 10_000);
+});
+
+test('resolveMitRemovalIds 会按当前是否被选中决定删除范围', () => {
+  const a = createMitEvent('role-rampart', 10_000, 'PLD', 1);
+
+  assert.deepEqual(resolveMitRemovalIds(a, ['x', a.id]), ['x', a.id]);
+  assert.deepEqual(resolveMitRemovalIds(a, ['x']), [a.id]);
+});
+
+test('buildMitEventFromSkill 会生成带 owner 的减伤事件', () => {
+  const mit = buildMitEventFromSkill({
+    skillId: 'role-reprisal',
+    tStartMs: 15_000,
+    id: 'mit-1',
+    ownerJob: 'PLD',
+    ownerId: 42,
+  });
+
+  assert.ok(mit);
+  if (!mit) {
+    throw new Error('期望生成减伤事件');
+  }
+  assert.equal(mit.id, 'mit-1');
+  assert.equal(mit.skillId, 'role-reprisal@PLD');
+  assert.equal(mit.ownerJob, 'PLD');
+  assert.equal(mit.ownerId, 42);
+  assert.equal(mit.tEndMs, mit.tStartMs + mit.durationMs);
+});
+
+test('canDropNewMitigation 会复用合法性校验结果', () => {
+  const events = [createMitEvent('role-rampart', 10_000, 'PLD', 1)];
+  const context = prepareExistingMitDrag(
+    createMitEvent('role-reprisal@PLD', 50_000, 'PLD', 1),
+    [],
+    events,
+  );
+
+  assert.equal(
+    canDropNewMitigation('role-rampart', 20_000, events, context.cooldownEvents, {
+      ownerJob: 'PLD',
+      ownerId: 1,
+    }),
+    false,
+  );
+  assert.equal(
+    canDropNewMitigation('role-rampart', 120_000, events, context.cooldownEvents, {
+      ownerJob: 'PLD',
+      ownerId: 1,
+    }),
+    true,
+  );
+});
+
+test('buildMovedMitEvents 会生成整体平移后的结果', () => {
+  const a = createMitEvent('role-rampart', 10_000, 'PLD', 1);
+  const b = createMitEvent('role-reprisal@PLD', 30_000, 'PLD', 1);
+  const context = prepareExistingMitDrag(a, [a.id, b.id], [a, b]);
+
+  const moved = buildMovedMitEvents({
+    sourceMit: a,
+    tStartMs: 20_000,
+    eventsToMove: context.eventsToMove,
+    mitEvents: [a, b],
+    cooldownEvents: context.cooldownEvents,
+  });
+
+  assert.deepEqual(
+    moved?.map((mit) => ({ id: mit.id, tStartMs: mit.tStartMs, tEndMs: mit.tEndMs })),
+    [
+      { id: a.id, tStartMs: 20_000, tEndMs: 30_000 },
+      { id: b.id, tStartMs: 40_000, tEndMs: 50_000 },
+    ],
+  );
+});
+
+test('canDropExistingMitigations 在目标时间冲突时返回 false', () => {
+  const moving = createMitEvent('role-rampart', 10_000, 'PLD', 1);
+  const blocker = createMitEvent('role-rampart', 120_000, 'PLD', 1);
+  const context = prepareExistingMitDrag(moving, [moving.id], [moving, blocker]);
+
+  assert.equal(
+    canDropExistingMitigations({
+      sourceMit: moving,
+      tStartMs: 100_000,
+      eventsToMove: context.eventsToMove,
+      mitEvents: [moving, blocker],
+      cooldownEvents: context.cooldownEvents,
+    }),
+    false,
+  );
+});

--- a/test/mitigationDrag.test.ts
+++ b/test/mitigationDrag.test.ts
@@ -46,7 +46,6 @@ test('prepareExistingMitDrag 会基于选中项生成移动上下文', () => {
   const result = prepareExistingMitDrag(a, [a.id, b.id], [a, b]);
 
   assert.deepEqual(result.eventsToMove, [a, b]);
-  assert.deepEqual(result.cooldownEvents, []);
 });
 
 test('resolveDropStartMs 会把拖拽落点转换为时间', () => {
@@ -114,7 +113,6 @@ test('buildMovedMitEvents 会生成整体平移后的结果', () => {
     tStartMs: 20_000,
     eventsToMove: context.eventsToMove,
     mitEvents: [a, b],
-    cooldownEvents: context.cooldownEvents,
   });
 
   assert.deepEqual(
@@ -137,8 +135,34 @@ test('canDropExistingMitigations 在目标时间冲突时返回 false', () => {
       tStartMs: 100_000,
       eventsToMove: context.eventsToMove,
       mitEvents: [moving, blocker],
-      cooldownEvents: context.cooldownEvents,
     }),
     false,
+  );
+});
+
+test('canDropExistingMitigations 会阻止多选移动破坏未选中的充能技能排布', () => {
+  const a = createMitEvent('drk-oblation', 0, 'DRK', 1);
+  const b = createMitEvent('drk-oblation', 30_000, 'DRK', 1);
+  const staticMit = createMitEvent('drk-oblation', 100_000, 'DRK', 1);
+  const context = prepareExistingMitDrag(a, [a.id, b.id], [a, b, staticMit]);
+
+  assert.equal(
+    canDropExistingMitigations({
+      sourceMit: a,
+      tStartMs: 50_000,
+      eventsToMove: context.eventsToMove,
+      mitEvents: [a, b, staticMit],
+    }),
+    false,
+  );
+
+  assert.equal(
+    buildMovedMitEvents({
+      sourceMit: a,
+      tStartMs: 50_000,
+      eventsToMove: context.eventsToMove,
+      mitEvents: [a, b, staticMit],
+    }),
+    null,
   );
 });

--- a/test/playerCast.test.ts
+++ b/test/playerCast.test.ts
@@ -2,7 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import type { Job, MitEvent } from '../src/model/types';
-import { canInsertMitigation, tryBuildCooldowns } from '../src/utils/playerCast';
+import {
+  buildCooldownsStrict,
+  buildCooldownsTolerant,
+  canInsertMitigation,
+  evaluateMitigationSetStrict,
+  tryBuildCooldowns,
+} from '../src/utils/playerCast';
 
 function createMitEvent(
   skillId: string,
@@ -151,5 +157,48 @@ test('同技能不同 owner 不会互相阻塞', () => {
   assert.equal(
     canInsertMitigation('role-rampart', 20_000, events, 'WAR', 2, undefined, cooldowns),
     true,
+  );
+});
+
+test('strict 模式会拒绝非法的单资源重复占用', () => {
+  const invalidEvents = [
+    createMitEvent('role-rampart', 10_000, 'PLD', 1),
+    createMitEvent('role-rampart', 20_000, 'PLD', 1),
+  ];
+
+  const strictResult = buildCooldownsStrict(invalidEvents);
+  assert.equal(strictResult.ok, false);
+
+  const tolerantCooldowns = buildCooldownsTolerant(invalidEvents);
+  assert.ok(tolerantCooldowns.length > 0);
+});
+
+test('evaluateMitigationSetStrict 会返回排序后的事件与 cooldowns', () => {
+  const later = createMitEvent('role-reprisal@PLD', 30_000, 'PLD', 1);
+  const earlier = createMitEvent('role-rampart', 10_000, 'PLD', 1);
+
+  const result = evaluateMitigationSetStrict([later, earlier]);
+
+  assert.equal(result.ok, true);
+  if (!result.ok) {
+    throw new Error('期望得到合法的减伤状态');
+  }
+
+  assert.deepEqual(
+    result.mitEvents.map((mit) => mit.id),
+    [earlier.id, later.id],
+  );
+  assert.ok(result.cooldownEvents.length > 0);
+});
+
+test('canInsertMitigation 在 strict 兜底构建失败时会直接拒绝', () => {
+  const invalidEvents = [
+    createMitEvent('role-rampart', 10_000, 'PLD', 1),
+    createMitEvent('role-rampart', 20_000, 'PLD', 1),
+  ];
+
+  assert.equal(
+    canInsertMitigation('role-rampart', 150_000, invalidEvents, 'PLD', 1, new Set()),
+    false,
   );
 });


### PR DESCRIPTION
- 重构拖拽相关代码结构，抽离拖拽纯逻辑、会话控制器和编辑弹层，降低 `App` 与时间轴组件的职责耦合，提升可维护性。
- 修复多选拖拽校验缺口，改为基于整组候选结果做合法性判断，避免非法落点被错误接受后导致冷却显示异常。
- 修复多选拖拽时联动预览条缺失技能图标的问题，改善拖拽过程中的视觉反馈一致性。
- 拆分冷却构建为 strict / tolerant 两套入口，仅 FFLogs 导入保留容错；新增、编辑、拖拽等运行时交互统一走严格校验，并改为一次求值后原子提交 `mitEvents` 与 `cooldownEvents`。